### PR TITLE
Pin the version of the allure report action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
           path: gh-pages
 
       - name: Generate Report
-        uses: simple-elf/allure-report-action@master
+        uses: simple-elf/allure-report-action@v1.6
         if: always() && github.ref == 'refs/heads/main'
         #id: allure-report
         with:


### PR DESCRIPTION
This is more secure as we don't run any code immediately when it is pushed to master.

Contributed on behalf of STMicroelectronics