### PR TITLE
Add performance measurement task

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,81 @@
+name: Performance
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *" # Runs every day at 5am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+
+jobs:
+  build:
+    name: Performance benchmark on ubuntu-latest with Node.js 16.x
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js "16.x"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Build
+        shell: bash
+        run: yarn
+
+      - name: Checkout Theia
+        uses: actions/checkout@v3
+        with:
+          repository: eclipse-theia/theia
+          path: ./theia
+
+      - name: Build Theia
+        shell: bash
+        working-directory: ./theia
+        run: |
+          yarn --skip-integrity-check --network-timeout 100000
+          yarn browser build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Run Theia
+        shell: bash
+        working-directory: ./theia
+        run: yarn browser start &
+
+      - name: Run Performance Measurement
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn performance
+
+      - name: Get History
+        uses: actions/checkout@v2
+        if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Prepare Report
+        if: always() && github.ref == 'refs/heads/main'
+        shell: bash
+        run: yarn performance-report
+
+      - name: Publish Report
+        if: always() && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        env:
+          PERSONAL_TOKEN: ${{ secrets.TOKEN }}
+          PUBLISH_DIR: ./public

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 node_modules
 allure-results
 test-results
+performance-metrics
+public
+gh-pages

--- a/configs/performance.config.ts
+++ b/configs/performance.config.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2021 logi.cals GmbH, EclipseSource and others.
+// Copyright (C) 2023 STMicroelectronics and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,28 +15,32 @@
 // *****************************************************************************
 
 import { PlaywrightTestConfig } from '@playwright/test';
+import { MetricsFetchConfig } from '../scripts/fetch-metrics';
 
-const config: PlaywrightTestConfig = {
+const performanceConfig: PlaywrightTestConfig = {
     testDir: '../lib/tests',
-    testMatch: ['**/*.test.js'],
-    workers: 2,
-    // Timeout for each test in milliseconds.
+    testMatch: ['**/*.performance.js'],
+    globalTeardown: require.resolve('../scripts/fetch-metrics.ts'),
+    workers: 1,
     timeout: 60 * 1000,
     use: {
         baseURL: 'http://localhost:3000',
         browserName: 'chromium',
-        screenshot: 'only-on-failure',
         viewport: { width: 1920, height: 1080 }
     },
-    snapshotDir: '../tests/snapshots',
-    expect: {
-        toMatchSnapshot: { threshold: 0.15 }
+    metadata: {
+        // custom metadata to configure /scripts/ci-global-tear-down.ts
+        performanceMetrics: <MetricsFetchConfig>{
+            metricsEndpoint: 'http://localhost:3000/metrics',
+            outputFileNamePrefix: '',
+            outputFileNamePostfix: '.txt',
+            outputFilePath: 'performance-metrics'
+        }
     },
     preserveOutput: 'failures-only',
     reporter: [
-        ['list'],
-        ['allure-playwright']
-    ]
+        ['list']
+    ],
 };
 
-export default config;
+export default performanceConfig;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "ui-tests-ci": "yarn && playwright test --config=./configs/playwright.ci.config.ts",
     "ui-tests-headful": "yarn && playwright test --config=./configs/playwright.headful.config.ts",
     "ui-tests-report-generate": "allure generate ./allure-results --clean -o allure-results/allure-report",
-    "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report"
+    "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report",
+    "performance": "yarn && playwright test --config=./configs/performance.config.ts",
+    "performance-report": "yarn && node lib/scripts/performance-report.js"
   },
   "dependencies": {
     "@playwright/test": "^1.35.1",
@@ -21,6 +23,12 @@
     "allure-commandline": "^2.23.0",
     "allure-playwright": "^2.4.0",
     "rimraf": "^3.0.0",
+    "node-fetch": "^2.6.7",
+    "@types/node-fetch": "^2.6.4",
+    "fs-extra": "^11.1.1",
+    "@types/fs-extra": "^11.0.1",
+    "yargs": "^17.7.2",
+    "@types/yargs": "^17.0.24",
     "typescript": "~4.5.5"
   }
 }

--- a/scripts/fetch-metrics.ts
+++ b/scripts/fetch-metrics.ts
@@ -1,0 +1,69 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { type FullConfig } from '@playwright/test';
+import * as fs from 'fs-extra';
+import fetch from 'node-fetch';
+
+async function fetchMetrics(config: FullConfig) {
+    await fetchPerformanceMetrics(config.metadata.performanceMetrics, config.metadata.totalTime);
+}
+
+export default fetchMetrics;
+
+export interface MetricsFetchConfig {
+    metricsEndpoint: string;
+    outputFileNamePrefix: string;
+    outputFileNamePostfix: string;
+    outputFilePath: string;
+}
+
+export async function fetchPerformanceMetrics({
+    metricsEndpoint,
+    outputFileNamePrefix,
+    outputFileNamePostfix,
+    outputFilePath }: MetricsFetchConfig,
+    totalTime?: string
+) {
+    const now = new Date();
+    const dateString = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
+    const timeString = `${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;
+    const timestamp = `${dateString}T${timeString}`;
+    const fileName = outputFileNamePrefix + timestamp + outputFileNamePostfix;
+    const targetFile = `${outputFilePath}/${fileName}`;
+
+    fs.ensureDirSync(outputFilePath);
+    if (fs.existsSync(targetFile)) {
+        console.warn('Output file already exists, deleting it...');
+        fs.rmSync(targetFile);
+    }
+
+    try {
+        const response = await fetch(metricsEndpoint);
+        let data = await response.text();
+        if (totalTime) {
+            data += `
+
+playwright_total_time ${totalTime}`;
+        }
+
+        fs.writeFileSync(targetFile, data);
+    } catch (error) {
+        console.error('Error while fetching metrics', error);
+        process.exit(-1);
+    }
+}
+

--- a/scripts/performance-report.ts
+++ b/scripts/performance-report.ts
@@ -1,0 +1,181 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as events from 'events';
+import * as fs from 'fs-extra';
+import * as readline from 'readline';
+import yargs from 'yargs';
+
+(async () => {
+    const options: PerformanceReportParams = yargs(process.argv)
+        .option('ghPagesPath', {
+            describe: 'The path where the history of previous gh pages publications are located.',
+            default: 'gh-pages',
+            type: 'string'
+        })
+        .option('publishPath', {
+            describe: 'The path to which the new gh pages files including history should end up.',
+            default: 'public',
+            type: 'string'
+        })
+        .option('performancePublishPath', {
+            describe: 'The path relative to `publishPath` for the performance data and report.',
+            default: 'performance',
+            type: 'string'
+        })
+        .option('performanceMetricsPath', {
+            describe: 'The path where the latest performance metrics are located.',
+            default: 'performance-metrics',
+            type: 'string'
+        })
+        .parseSync();
+    preparePerformanceReport(options);
+})();
+
+interface PerformanceReportParams {
+    /** The path where the history of previous gh pages publications are located. */
+    ghPagesPath: string;
+    /** The path to which the new gh pages files including history should end up. */
+    publishPath: string;
+    /** The path relative to `publishPath` for the performance data and report. */
+    performancePublishPath: string;
+    /** The path where the latest performance metrics are located. */
+    performanceMetricsPath: string;
+}
+
+export async function preparePerformanceReport({
+    publishPath,
+    ghPagesPath,
+    performancePublishPath,
+    performanceMetricsPath
+}: PerformanceReportParams) {
+    // copy history from the current gh-pages folder to new publish path
+    console.log('Copying history');
+    fs.emptyDirSync(publishPath);
+    fs.copySync(ghPagesPath, publishPath);
+    // copy latest performance metrics into performance publish path
+    console.log('Copying performance metrics');
+    fs.ensureDirSync(`${publishPath}/${performancePublishPath}`);
+    fs.copySync(performanceMetricsPath, `${publishPath}/${performancePublishPath}`);
+    // generate performance report
+    console.log('Generating performance report');
+    generatePerformanceReport(`${publishPath}/${performancePublishPath}`);
+}
+
+interface ValueHistoryEntry {
+    entryLabel: string;
+    value: number;
+}
+interface ValueHistory {
+    valueLabel: string;
+    history: ValueHistoryEntry[];
+}
+
+export async function generatePerformanceReport(path: string) {
+    const reportPath = path + '/index.html';
+    if (fs.existsSync(path + '/index.html')) {
+        fs.removeSync(reportPath);
+    }
+
+    const values = await readValuesFromHistory(path, ['process_cpu_seconds_total', 'playwright_total_time']);
+    const charts: string[] = [];
+    for (const [valueLabel, valueHistory] of values) {
+        const data = valueHistory.history.map(entry => ({ x: entry.entryLabel, y: entry.value }));
+        charts.push(`
+        <div class="chart">
+        <h2>${valueLabel}</h2>
+        <canvas id="${valueLabel}" style="width:100%;max-height: 500px;"></canvas>
+        <script>
+        const ctx${valueLabel} = document.getElementById('${valueLabel}');
+        new Chart(ctx${valueLabel}, {
+            type: 'line',
+            data: {
+            datasets: [{
+                label: '${valueLabel}',
+                data: ${JSON.stringify(data)}
+            }]
+            }
+        });
+        </script>
+        </div>
+        `);
+    }
+
+    const html = `
+        <!doctype html>
+        <head>
+        <meta charset="utf-8">
+        <title>Theia Performance Report</title>
+        <meta name="description" content="Theia Performance Report">
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        </head>
+        
+        <body>
+        <h1>Theia Performance Report</h1>
+        <div class="charts">
+        ${charts.join(' ')}
+        </div>    
+        </script>
+        </body>
+        </html>
+    `;
+
+    fs.writeFileSync(reportPath, html);
+}
+
+export async function readValuesFromHistory(path: string, values: string[]): Promise<Map<string, ValueHistory>> {
+    const valueHistoryMap = initializeValueHistoryMap(values);
+    const files = fs.readdirSync(path).sort();
+    for (const file of files) {
+        if (file.endsWith('index.html')) {
+            continue;
+        }
+        const entryLabel = file.substring(0, file.indexOf('.'));
+        const entries = await readEntries(path + '/' + file, values);
+        entries.forEach(entry =>
+            valueHistoryMap.get(entry.valueLabel)?.history.push({ entryLabel, value: entry.entryValue })
+        );
+    }
+    return valueHistoryMap;
+}
+
+export function initializeValueHistoryMap(values: string[]) {
+    const valueHistoryMap = new Map<string, ValueHistory>();
+    for (const value of values) {
+        const history: ValueHistoryEntry[] = [];
+        valueHistoryMap.set(value, { valueLabel: value, history });
+    }
+    return valueHistoryMap;
+}
+
+export async function readEntries(path: string, values: string[]): Promise<{ valueLabel: string, entryValue: number }[]> {
+    const entries: { valueLabel: string, entryValue: number }[] = [];
+    try {
+        const rl = readline.createInterface({ input: fs.createReadStream(path), crlfDelay: Infinity });
+        rl.on('line', (line) => {
+            for (const valueLabel of values) {
+                if (line.startsWith(valueLabel + ' ')) {
+                    const entryValue = Number.parseFloat(line.split(' ')[1]);
+                    entries.push({ valueLabel, entryValue });
+                }
+            }
+        });
+        await events.once(rl, 'close');
+    } catch (err) {
+        console.error(err);
+    }
+    return entries;
+}

--- a/tests/theia.performance.ts
+++ b/tests/theia.performance.ts
@@ -16,12 +16,10 @@
 
 import { expect, test } from '@playwright/test';
 import { TheiaApp, TheiaTextEditor, TheiaWorkspace } from '@theia/playwright';
-import { allure } from "allure-playwright";
 
 test.describe('Theia App', () => {
 
     test('should be fast in opening, changing and saving a text file', async ({ browser }) => {
-        allure.tag('performance');
         const page = await browser.newPage();
         const ws = new TheiaWorkspace(['tests/resources/sample-files1']);
         const app = await TheiaApp.loadApp(page, TheiaApp, ws);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
   },
   "include": [
     "configs",
-    "tests"
+    "tests",
+    "scripts"
   ],
   "references": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,45 @@
     "@playwright/test" "^1.32.1"
     fs-extra "^9.0.8"
 
+"@types/fs-extra@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.1.tgz#f542ec47810532a8a252127e6e105f487e0a6ea5"
+  integrity sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==
+  dependencies:
+    "@types/jsonfile" "*"
+    "@types/node" "*"
+
+"@types/jsonfile@*":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.1.tgz#ac84e9aefa74a2425a0fb3012bdea44f58970f1b"
+  integrity sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node-fetch@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.4.tgz#1bc3a26de814f6bf466b25aeb1473fa1afe6a660"
+  integrity sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "17.0.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
   integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
+
+"@types/yargs-parser@*":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
+  integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
+
+"@types/yargs@^17.0.24":
+  version "17.0.24"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.24.tgz#b3ef8d50ad4aa6aecf6ddc97c580a00f5aa11902"
+  integrity sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 allure-commandline@^2.23.0:
   version "2.23.0"
@@ -45,6 +80,23 @@ allure-playwright@^2.4.0:
   dependencies:
     allure-js-commons "2.4.0"
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
@@ -63,10 +115,71 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.0.8:
   version "9.1.0"
@@ -87,6 +200,11 @@ fsevents@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 glob@^7.1.3:
   version "7.2.0"
@@ -118,6 +236,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -127,12 +250,31 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+node-fetch@^2.6.7:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
+  integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 once@^1.3.0:
   version "1.4.0"
@@ -156,12 +298,38 @@ properties@^1.2.1:
   resolved "https://registry.yarnpkg.com/properties/-/properties-1.2.1.tgz#0ee97a7fc020b1a2a55b8659eda4aa8d869094bd"
   integrity sha1-Dul6f8AgsaKlW4ZZ7aSqjYaQlL0=
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 typescript@~4.5.5:
   version "4.5.5"
@@ -178,7 +346,52 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"


### PR DESCRIPTION
With this change we introduce a separate Github action that periodically runs a performance measurement and collects values after each run via Theia's prometheus endpoint (`/metrics`). These values are kept persistent over time in the github pages.

Also we generate an initial report with graphs that plot the playwright execution time and the CPU seconds of each run.
This report will be available at:
https://eclipse-theia.github.io/theia-e2e-test-suite/performance

Contributed on behalf of STMicroelectronics