### PR TITLE
Publish allure reports into subdirectory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
           #allure_report: allure-report
           allure_history: allure-history
           keep_reports: 100
+          subfolder: allure
 
       - name: Publish Report
         if: always() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Update the CI workflow to publish allure reports into the `allure` subdirectory instead of the root. This ensure that the cleanup behavior (remove old reports) of the corresponding github action does not interfere with other unrelated results. (e.g. removing the performance history directory instead of an old test directory)

Requires https://github.com/eclipse-theia/theia-e2e-test-suite/pull/17.
(Updates the gh-pages branch to the expected directory structure and restores previously deleted performance history)