### PR TITLE
Add electron tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   build:
     name: E2E Tests on ubuntu-latest with Node.js 16.x
-
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -50,19 +49,101 @@ jobs:
         run: |
           yarn --skip-integrity-check --network-timeout 100000
           yarn browser build
+          yarn electron build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Cache Build Result
+        uses: actions/cache@v3
+        id: build-result
+        with:
+          path: ./*
+          key: ${{ github.run_number }}
+
+  browser-tests:
+    name: E2E Browser Tests on ubuntu-latest with Node.js 16.x
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [build]
+
+    steps:
+      - name: Restore Build Result (#${{ github.run_number }})
+        uses: actions/cache/restore@v3
+        id: build-result
+        with:
+          path: ./*
+          key: ${{ github.run_number }}
+          fail-on-cache-miss: true
+
+      - name: Use Node.js "16.x"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
       - name: Run Theia
         shell: bash
         working-directory: ./theia
         run: yarn browser start &
 
-      - name: Test (playwright)
-        uses: GabrielBB/xvfb-action@v1
+      - name: Test (playwright browser)
         with:
           run: yarn ui-tests-ci
+
+      - name: Upload test results (browser)
+        uses: actions/upload-artifact@v3
+        with:
+          name: ui-tests-browser-${{ github.run_number }}
+          path: allure_results/*
+
+  electron-tests:
+    name: E2E Electron Tests on ubuntu-latest with Node.js 16.x
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [build]
+
+    steps:
+      - name: Restore Build Result (#${{ github.run_number }})
+        uses: actions/cache/restore@v3
+        id: build-result
+        with:
+          path: ./*
+          key: ${{ github.run_number }}
+          fail-on-cache-miss: true
+
+      - name: Use Node.js "16.x"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Test (playwright electron)
+        with:
+          run: xvfb-run yarn ui-tests-ci-electron
+
+      - name: Upload test results (electron)
+        uses: actions/upload-artifact@v3
+        with:
+          name: ui-tests-electron-${{ github.run_number }}
+          path: allure_results/*
+
+  generate-report:
+    name: E2E Electron Tests on ubuntu-latest with Node.js 16.x
+    runs-on: ubuntu-latest
+    needs: [browser-tests, electron-tests]
+
+    steps:
 
       - name: Get History
         uses: actions/checkout@v2
@@ -71,6 +152,13 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
+
+      - name: Download test results
+        uses: actions/download-artifact@v3
+        with:
+          path: ui-tests-*-${{ github.run_number }}
+          merge-multiple: true
+          path: allure_results
 
       - name: Generate Report
         uses: simple-elf/allure-report-action@master

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -34,6 +34,7 @@ jobs:
         shell: bash
         run: |
           cp -f ./configs/theia.production.webpack.config.js ./theia/examples/browser/webpack.config.js
+          cp -f ./configs/theia.production.webpack.config.js ./theia/examples/electron/webpack.config.js
       - name: Build Theia
         shell: bash
         working-directory: ./theia
@@ -51,6 +52,14 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+      - name: Build Electron App (Production)
+        shell: bash
+        working-directory: ./theia/examples/electron
+        run: |
+          yarn -s compile && yarn rebuild && yarn theia build --mode=production
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
       - name: Cache Build Result
         uses: actions/cache@v3
         id: build-result
@@ -58,8 +67,8 @@ jobs:
           path: ./*
           key: ${{ github.run_number }}
 
-  run-test:
-    name: Performance benchmark on ubuntu-latest with Node.js 16.x
+  run-browser-tests:
+    name: Performance browser benchmark on ubuntu-latest with Node.js 16.x
     runs-on: ubuntu-latest
     needs: [prepare]
     strategy:
@@ -79,35 +88,75 @@ jobs:
         with:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
-      - name: Use Python 3.x
+      - name: Use Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
       - name: Get History
         uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages
-      - name: Run Theia (#${{ matrix.run }})
+      - name: Run Theia browser backend (#${{ matrix.run }})
         shell: bash
         working-directory: ./theia
         run: yarn browser start:debug &
-      - name: Run Performance Measurement (#${{ matrix.run }})
-        uses: GabrielBB/xvfb-action@v1
+      - name: Run Performance Measurement: browser (#${{ matrix.run }})
         env:
           RUN_NO: ${{ matrix.run }}
         with:
           run: yarn performance
-      - name: Upload performance measurement (#${{ matrix.run }})
+      - name: Upload performance measurement: browser (#${{ matrix.run }})
         uses: actions/upload-artifact@v3
         with:
-          name: performance-measurement-${{ github.run_number }}
+          name: performance-measurement-browser-${{ github.run_number }}
+          path: performance-metrics/*
+
+  run-electron-tests:
+    name: Performance electron benchmark on ubuntu-latest with Node.js 16.x
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    strategy:
+      matrix:
+        run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    timeout-minutes: 40
+    steps:
+      - name: Restore Build Result (#${{ matrix.run }})
+        uses: actions/cache/restore@v3
+        id: build-result
+        with:
+          path: ./*
+          key: ${{ github.run_number }}
+          fail-on-cache-miss: true
+      - name: Use Node.js "16.x"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Use Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Get History
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Run Performance Measurement: electron (#${{ matrix.run }})
+        env:
+          RUN_NO: ${{ matrix.run }}
+        with:
+          run: xvfb-run yarn performance-on-electron
+      - name: Upload performance measurement: electron (#${{ matrix.run }})
+        uses: actions/upload-artifact@v3
+        with:
+          name: performance-measurement-electron-${{ github.run_number }}
           path: performance-metrics/*
 
   generate-report:
     name: Performance benchmark on ubuntu-latest with Node.js 16.x
     runs-on: ubuntu-latest
-    needs: [run-test]
+    needs: [run-browser-tests, run-electron-tests]
     steps:
       - name: Restore Build Result
         uses: actions/cache/restore@v3
@@ -126,12 +175,17 @@ jobs:
       - name: Download Performance Measurements
         uses: actions/download-artifact@v3
         with:
-          name: performance-measurement-${{ github.run_number }}
+          pattern: performance-measurement-*-${{ github.run_number }}
+          merge-multiple: true
           path: performance-metrics
-      - name: Prepare Report
+      - name: Prepare Browser Report
         if: always() && github.ref == 'refs/heads/main'
         shell: bash
         run: yarn performance-report
+      - name: Prepare Electron Report
+        if: always() && github.ref == 'refs/heads/main'
+        shell: bash
+        run: yarn performance-report-electron
       - name: Publish Report
         if: always() && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v2

--- a/configs/performance.config.ts
+++ b/configs/performance.config.ts
@@ -20,7 +20,6 @@ import { MetricsFetchConfig } from '../scripts/fetch-metrics';
 export default defineConfig({
     testDir: '../lib/tests',
     testMatch: ['**/*.performance.js'],
-    globalTeardown: require.resolve('../scripts/fetch-metrics.ts'),
     workers: 1,
     timeout: 60 * 1000,
     use: {
@@ -51,6 +50,9 @@ export default defineConfig({
                 ...devices['Desktop Chrome'],
                 channel: 'chrome'
             },
-        }
+        },
+        {
+            name: 'Electron',
+        },
     ]
 });

--- a/configs/playwright.config.ts
+++ b/configs/playwright.config.ts
@@ -36,6 +36,14 @@ const config: PlaywrightTestConfig = {
     reporter: [
         ['list'],
         ['allure-playwright']
+    ],
+    projects: [
+        {
+            name: 'Browser',
+        },
+        {
+            name: 'Electron',
+        }
     ]
 };
 

--- a/package.json
+++ b/package.json
@@ -1,37 +1,41 @@
 {
   "private": true,
   "name": "theia-e2e-test-suite",
-  "version": "1.39.0",
+  "version": "1.46.1",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "scripts": {
     "prepare": "yarn clean && yarn build",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
     "build": "tsc --incremental && if-env SKIP_CHROMIUM_INSTALLATION=1 && echo 'Skipping chromium install' || npx playwright install chromium",
-    "ui-tests": "yarn && playwright test --config=./configs/playwright.config.ts",
-    "ui-tests-ci": "yarn && playwright test --config=./configs/playwright.ci.config.ts",
-    "ui-tests-headful": "yarn && playwright test --config=./configs/playwright.headful.config.ts",
+    "ui-tests": "yarn && playwright test --config=./configs/playwright.config.ts --project=Browser",
+    "ui-tests-electron": "yarn && USE_ELECTRON=true playwright test --config=./configs/playwright.config.ts --project=Electron",
+    "ui-tests-ci": "yarn && playwright test --config=./configs/playwright.ci.config.ts --project=Browser",
+    "ui-tests-ci-electron": "yarn && USE_ELECTRON=true playwright test --config=./configs/playwright.ci.config.ts --project=Electron",
+    "ui-tests-headful": "yarn && playwright test --config=./configs/playwright.headful.config.ts --project=Browser",
     "ui-tests-report-generate": "allure generate ./allure-results --clean -o allure-results/allure-report",
     "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report",
     "performance": "yarn run performance-on-chromium",
     "performance-on-chromium": "yarn && playwright test --config=./configs/performance.config.ts --project=chromium",
     "performance-on-chrome": "yarn && playwright test --config=./configs/performance.config.ts --project=Chrome",
-    "performance-report": "yarn && node lib/scripts/performance-report.js"
+    "performance-on-electron": "yarn && USE_ELECTRON=true playwright test --config=./configs/performance.config.ts --project=Electron",
+    "performance-report": "yarn && node lib/scripts/performance-report.js --performanceMetricsPath performance-metrics/chromium --performancePublishPath=performance/chromium",
+    "performance-report-electron": "yarn && node lib/scripts/performance-report.js --performanceMetricsPath performance-metrics/Electron --performancePublishPath=performance/Electron"
   },
   "dependencies": {
-    "@playwright/test": "^1.35.1",
-    "@theia/playwright": "^1.39.0"
+    "@playwright/test": "^1.37.1",
+    "@theia/playwright": "^1.46.1"
   },
   "devDependencies": {
-    "allure-commandline": "^2.23.0",
-    "allure-playwright": "^2.4.0",
-    "rimraf": "^3.0.0",
-    "node-fetch": "^2.6.7",
-    "@types/node-fetch": "^2.6.4",
-    "fs-extra": "^11.1.1",
     "@types/fs-extra": "^11.0.1",
-    "yargs": "^17.7.2",
+    "@types/node-fetch": "^2.6.4",
     "@types/yargs": "^17.0.24",
+    "allure-commandline": "^2.23.1",
+    "allure-playwright": "^2.5.0",
+    "fs-extra": "^11.1.1",
     "if-env": "^1.0.4",
-    "typescript": "~4.5.5"
+    "node-fetch": "^2.6.7",
+    "rimraf": "^3.0.0",
+    "typescript": "~4.5.5",
+    "yargs": "^17.7.2"
   }
 }

--- a/scripts/fetch-metrics.ts
+++ b/scripts/fetch-metrics.ts
@@ -18,8 +18,8 @@ import { type FullConfig } from '@playwright/test';
 import * as fs from 'fs-extra';
 import fetch from 'node-fetch';
 
-async function fetchMetrics(config: FullConfig) {
-    await fetchPerformanceMetrics(config.metadata.performanceMetrics, config.metadata.totalTime);
+async function fetchMetrics(projectName: string, config: FullConfig) {
+    await fetchPerformanceMetrics(projectName, config.metadata.performanceMetrics, config.metadata.totalTime);
 }
 
 export default fetchMetrics;
@@ -31,13 +31,17 @@ export interface MetricsFetchConfig {
     outputFilePath: string;
 }
 
-export async function fetchPerformanceMetrics({
-    metricsEndpoint,
-    outputFileNamePrefix,
-    outputFileNamePostfix,
-    outputFilePath }: MetricsFetchConfig,
+export async function fetchPerformanceMetrics(
+    projectName: string,
+    {
+        metricsEndpoint,
+        outputFileNamePrefix,
+        outputFileNamePostfix,
+        outputFilePath
+    }: MetricsFetchConfig,
     totalTime?: string
 ) {
+    outputFilePath = `${outputFilePath}/${projectName}`;
     const now = new Date();
     const dateString = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
     const timeString = `${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;

--- a/tests/theia-app.test.ts
+++ b/tests/theia-app.test.ts
@@ -13,19 +13,23 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { expect, Page, test } from '@playwright/test';
-import { TheiaApp } from '@theia/playwright';
+import { expect, test } from '@playwright/test';
+import { TheiaApp, TheiaAppLoader } from '@theia/playwright';
 
-let page: Page;
 let app: TheiaApp;
 
-test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-    app = await TheiaApp.loadApp(page, TheiaApp);
+test.beforeAll(async ({ playwright, browser }) => {
+    app = await TheiaAppLoader.load({
+        playwright, useElectron: { electronAppPath: 'theia/examples/electron', }, browser
+    });
 });
 
-test.describe('Theia app', () => {
+test.afterAll(async () => {
+    await app.page.close();
+});
 
+
+test.describe('Theia app', () => {
     test('should show main content panel', async () => {
         expect(await app.isMainContentPanelVisible()).toBe(true);
     });

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (C) 2024 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { TheiaApp, TheiaExplorerView } from "@theia/playwright";
+
+export async function initializeExplorer(app: TheiaApp): Promise<void> {
+    // workaround for multi-root workspaces in Electron
+    if (app.isElectron) {
+        const explorer = await app.openView(TheiaExplorerView);
+        await explorer.waitForVisibleFileNodes();
+        console.log(`app.workspace.path = ${app.workspace.path}`);
+        const workspaceBasename = app.workspace.path.split('/').pop();
+        if (workspaceBasename) {
+            await app.page.getByText(workspaceBasename).click();
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,19 @@
 # yarn lockfile v1
 
 
-"@playwright/test@^1.32.1", "@playwright/test@^1.35.1":
-  version "1.35.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.35.1.tgz#a596b61e15b980716696f149cc7a2002f003580c"
-  integrity sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==
+"@playwright/test@^1.37.1":
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.41.2.tgz#bd9db40177f8fd442e16e14e0389d23751cdfc54"
+  integrity sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==
   dependencies:
-    "@types/node" "*"
-    playwright-core "1.35.1"
-  optionalDependencies:
-    fsevents "2.3.2"
+    playwright "1.41.2"
 
-"@theia/playwright@^1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@theia/playwright/-/playwright-1.39.0.tgz#e74da1ac05dafeda134f086ccc54f2cb70135625"
-  integrity sha512-P6e5mfYINiaA3tcQ5o7Z1Yc9vZJ0eWPTnSnFrDAwkgzP2AaDiSbr2ZUeuiyFvQBoZNzfpxJ6csheYkA/LMd/OA==
+"@theia/playwright@^1.46.1":
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/@theia/playwright/-/playwright-1.46.1.tgz#f80b40380f3e687ddc1d89e3a51d664010905c5e"
+  integrity sha512-6RD/nfNSgwwqhvG91vXg2PzU1j5awh6FNnWr+FFCPyJ1VnQCbYmg9BV/xyLI2nW/4xFL3Aw70Bhgk3CG2l6jUg==
   dependencies:
-    "@playwright/test" "^1.32.1"
+    "@playwright/test" "^1.37.1"
     fs-extra "^9.0.8"
 
 "@types/fs-extra@^11.0.1":
@@ -60,25 +57,30 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-allure-commandline@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/allure-commandline/-/allure-commandline-2.23.0.tgz#fdea57adee905808c0953ac51a234e474e9f5c27"
-  integrity sha512-bfAbyQzke0Gj48bxIAhHOcJ6DluYeR4uz3iQ1wJWx7TgGA1gazN1PXUtpr+wnX9eXCTRApEuggaJIduLik7Wsg==
+allure-commandline@^2.23.1:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/allure-commandline/-/allure-commandline-2.27.0.tgz#abde1a14d4b95e7f63dd727a4bb2e5df44e03fe0"
+  integrity sha512-KuxKEZ2Joa0LCcM9w8AWgWJgmB5d3VqSgaJhPC6pEsdRwAObT/JE8NY0u4mJ61+c2mhAPGIetGV9jgP3gzxgIg==
 
-allure-js-commons@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/allure-js-commons/-/allure-js-commons-2.4.0.tgz#1f75ff0ac153e30aaf4a4eb835fc6e55ee6610c6"
-  integrity sha512-mIQKAA91ihtMPzHJh7fQib/8MhZaUQ0oYtqFzS//5/Q+ILbMWW3WD2ISWtwniFAF2XWdRFjZ013IfUuKusbh1g==
+allure-js-commons@2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/allure-js-commons/-/allure-js-commons-2.12.2.tgz#2a9871309f6c95decbfdea12bf6ee0daa926e2da"
+  integrity sha512-bapkOHuwOYFR62aeNNwFmf8+LZSchzQ4Q8cFXWvEqP5fBTgADA+GujsRl936gjmTmKWVmKYwQfUt+PZw6tgFzw==
   dependencies:
     properties "^1.2.1"
-    uuid "^8.3.0"
+    strip-ansi "^5.2.0"
 
-allure-playwright@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/allure-playwright/-/allure-playwright-2.4.0.tgz#8b8ce4ac27290dbc87120029d12aefc8b1477b75"
-  integrity sha512-YtOdQXKPUFFfXVEPUaH5ebNf/2tLmJ1q898l+TPCPBeTQWVpKxLJm5yQkBbu+cmbsN+FGCsfDHFiqcS/r6f71w==
+allure-playwright@^2.5.0:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/allure-playwright/-/allure-playwright-2.12.2.tgz#44d46263a11b071e0cab7b1ade2ebb207ebb792b"
+  integrity sha512-QvDyCHABYlZ02PyGevbBZc9tS+Li0zXhTaTC1IJ2wJrd8q9cSS3mUnzAJUjPUuCtofdLBwePd2AuzsYE2ZXEJQ==
   dependencies:
-    allure-js-commons "2.4.0"
+    allure-js-commons "2.12.2"
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -352,7 +354,7 @@ npm-run-all@1.4.0:
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
@@ -368,10 +370,19 @@ pause-stream@0.0.11:
   dependencies:
     through "~2.3"
 
-playwright-core@1.35.1:
-  version "1.35.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.1.tgz#52c1e6ffaa6a8c29de1a5bdf8cce0ce290ffb81d"
-  integrity sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==
+playwright-core@1.41.2:
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.41.2.tgz#db22372c708926c697acc261f0ef8406606802d9"
+  integrity sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==
+
+playwright@1.41.2:
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.41.2.tgz#4e760b1c79f33d9129a8c65cc27953be6dd35042"
+  integrity sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==
+  dependencies:
+    playwright-core "1.41.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 properties@^1.2.1:
   version "1.2.1"
@@ -435,6 +446,13 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -461,11 +479,6 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
* Update theia dependency to 1.46.1
* Use new TheiaApploader
* Add workaround for Electron playwright multi-root issue
* Adjust workflows
* Rename existing performance reports to performance/chromium

The electron performance tests depend on Theia > 1.46.1 because they need to access the metrics endpoint.