### PR TITLE
fix: disable splash screen before building Theia Electron

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,12 @@ jobs:
           repository: eclipse-theia/theia
           path: ./theia
 
+      - name: Patch Theia to disable splash screen
+        shell: bash
+        working-directory: ./theia
+        run: |
+          sed -i '/"splashScreenOptions": {/,/}/c\          "splashScreenOptions": {}' examples/electron/package.json
+
       - name: Build Theia
         shell: bash
         working-directory: ./theia

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           repository: eclipse-theia/theia
           path: ./theia
+      - name: Patch Theia to disable splash screen
+        shell: bash
+        working-directory: ./theia
+        run: |
+          sed -i '/"splashScreenOptions": {/,/}/c\          "splashScreenOptions": {}' examples/electron/package.json
       - name: Copy webpack config
         shell: bash
         run: |


### PR DESCRIPTION
The splash screen interferes with the Electron tests, causing them to fail. Therefore, we disable it in the package.json of the electron example app.

Contributed on behalf of STMicroelectronics