### PR TITLE
Pin Ubuntu CI versions to 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ on:
 
 jobs:
   build:
-    name: E2E Tests on ubuntu-latest with Node.js 20.x
-    runs-on: ubuntu-latest
+    name: E2E Tests on ubuntu-22.04 with Node.js 20.x
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:
@@ -68,8 +68,8 @@ jobs:
           key: ${{ github.run_number }}
 
   browser-tests:
-    name: E2E Browser Tests on ubuntu-latest with Node.js 20.x
-    runs-on: ubuntu-latest
+    name: E2E Browser Tests on ubuntu-22.04 with Node.js 20.x
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: [build]
 
@@ -109,8 +109,8 @@ jobs:
           path: allure-results/*
 
   electron-tests:
-    name: E2E Electron Tests on ubuntu-latest with Node.js 20.x
-    runs-on: ubuntu-latest
+    name: E2E Electron Tests on ubuntu-22.04 with Node.js 20.x
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: [build]
 
@@ -146,7 +146,7 @@ jobs:
 
   generate-report:
     name: Generate Report of E2E Electron Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [browser-tests, electron-tests]
 
     steps:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   prepare:
-    name: Performance benchmark on ubuntu-latest with Node.js 20.x
-    runs-on: ubuntu-latest
+    name: Performance benchmark on ubuntu-22.04 with Node.js 20.x
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -73,8 +73,8 @@ jobs:
           key: ${{ github.run_number }}
 
   run-browser-tests:
-    name: Performance browser benchmark on ubuntu-latest with Node.js 20.x
-    runs-on: ubuntu-latest
+    name: Performance browser benchmark on ubuntu-22.04 with Node.js 20.x
+    runs-on: ubuntu-22.04
     needs: [prepare]
     strategy:
       matrix:
@@ -118,8 +118,8 @@ jobs:
           path: performance-metrics/*
 
   run-electron-tests:
-    name: Performance electron benchmark on ubuntu-latest with Node.js 20.x
-    runs-on: ubuntu-latest
+    name: Performance electron benchmark on ubuntu-22.04 with Node.js 20.x
+    runs-on: ubuntu-22.04
     needs: [prepare]
     strategy:
       matrix:
@@ -160,7 +160,7 @@ jobs:
 
   generate-report:
     name: Create Performance Report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [run-browser-tests, run-electron-tests]
     steps:
       - name: Restore Build Result


### PR DESCRIPTION
This change adapts to the changes made in Theia via https://github.com/eclipse-theia/theia/pull/14275.

Contributed on behalf of STMicroelectronics.