### PR TITLE
Fix browser performance report and archive old reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,12 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Build
         shell: bash
@@ -79,12 +79,12 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Install Playwright Chromium
         shell: bash
@@ -124,12 +124,12 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Install Playwright Chromium
         shell: bash
@@ -188,6 +188,8 @@ jobs:
         if: always() && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
-          personal_token: ${{ secrets.TOKEN }}
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: allure-history
+          user_name: "github-actions[bot]"
+          user_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -17,11 +17,11 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Use Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.13'
+          python-version: "3.13"
       - name: Build
         shell: bash
         run: npm ci
@@ -204,6 +204,8 @@ jobs:
         if: always() && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
-          personal_token: ${{ secrets.TOKEN }}
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: public
+          user_name: "github-actions[bot]"
+          user_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/scripts/performance-report.ts
+++ b/scripts/performance-report.ts
@@ -43,8 +43,8 @@ const matchUntilUnderscoreOrDot = /^([^\.\_])+/;
             default: 'performance-metrics',
             type: 'string'
         })
-        .option('maxAgeDays', {
-            describe: 'Only include metrics from the last N days in the report. Use 0 for no limit.',
+        .option('maxReports', {
+            describe: 'Only keep the last N reports (by unique date) in the active report. Use 0 for no limit.',
             default: 90,
             type: 'number'
         })
@@ -61,8 +61,8 @@ interface PerformanceReportParams {
     performancePublishPath: string;
     /** The path where the latest performance metrics are located. */
     performanceMetricsPath: string;
-    /** Only include metrics from the last N days in the report. Use 0 for no limit. */
-    maxAgeDays: number;
+    /** Only keep the last N reports (by unique date) in the active report. Use 0 for no limit. */
+    maxReports: number;
 }
 
 export async function preparePerformanceReport({
@@ -70,7 +70,7 @@ export async function preparePerformanceReport({
     ghPagesPath,
     performancePublishPath,
     performanceMetricsPath,
-    maxAgeDays
+    maxReports
 }: PerformanceReportParams) {
     // copy history from the current gh-pages folder to new publish path
     console.log('Copying history');
@@ -83,9 +83,9 @@ export async function preparePerformanceReport({
     fs.ensureDirSync(fullPerformancePath);
     fs.copySync(performanceMetricsPath, fullPerformancePath);
     // archive old metrics
-    if (maxAgeDays > 0) {
-        console.log(`Archiving metrics older than ${maxAgeDays} days`);
-        archiveOldMetrics(fullPerformancePath, maxAgeDays);
+    if (maxReports > 0) {
+        console.log(`Archiving all but the last ${maxReports} reports`);
+        archiveOldReports(fullPerformancePath, maxReports);
     }
     // generate performance report from remaining (non-archived) files
     console.log('Generating performance report');
@@ -117,17 +117,26 @@ function harmonizeFileNames(path: string) {
 }
 
 /**
- * Moves metric files older than `maxAgeDays` into an `archive/YYYY/` subdirectory.
- * Archived files are preserved but excluded from the active report.
+ * Keeps only the last `maxReports` reports (by unique date) and archives the rest.
+ * Each report may consist of multiple run files (e.g. `2024-3-5T14-19-16_0.txt` through `_9.txt`).
  */
-function archiveOldMetrics(path: string, maxAgeDays: number) {
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - maxAgeDays);
-
-    const files = fs.readdirSync(path).filter(hasTxtExtension);
+function archiveOldReports(path: string, maxReports: number) {
+    const files = fs.readdirSync(path).filter(hasTxtExtension).sort(sortByDateAndRunNumber);
+    // Group files by their date (strip run number)
+    const reportDates = new Map<string, string[]>();
     for (const file of files) {
-        const fileDate = toDate(file);
-        if (fileDate < cutoff) {
+        const runNumber = extractRunNumber(file);
+        const dateKey = extractDateString(file, runNumber);
+        if (!reportDates.has(dateKey)) {
+            reportDates.set(dateKey, []);
+        }
+        reportDates.get(dateKey)!.push(file);
+    }
+    const sortedDates = [...reportDates.keys()].sort((a, b) => toDate(a).getTime() - toDate(b).getTime());
+    const datesToArchive = sortedDates.slice(0, Math.max(0, sortedDates.length - maxReports));
+    for (const dateKey of datesToArchive) {
+        for (const file of reportDates.get(dateKey)!) {
+            const fileDate = toDate(file);
             const year = fileDate.getFullYear();
             const archiveDir = `${path}/archive/${year}`;
             fs.ensureDirSync(archiveDir);

--- a/scripts/performance-report.ts
+++ b/scripts/performance-report.ts
@@ -43,6 +43,11 @@ const matchUntilUnderscoreOrDot = /^([^\.\_])+/;
             default: 'performance-metrics',
             type: 'string'
         })
+        .option('maxAgeDays', {
+            describe: 'Only include metrics from the last N days in the report. Use 0 for no limit.',
+            default: 90,
+            type: 'number'
+        })
         .parseSync();
     preparePerformanceReport(options);
 })();
@@ -56,26 +61,35 @@ interface PerformanceReportParams {
     performancePublishPath: string;
     /** The path where the latest performance metrics are located. */
     performanceMetricsPath: string;
+    /** Only include metrics from the last N days in the report. Use 0 for no limit. */
+    maxAgeDays: number;
 }
 
 export async function preparePerformanceReport({
     publishPath,
     ghPagesPath,
     performancePublishPath,
-    performanceMetricsPath
+    performanceMetricsPath,
+    maxAgeDays
 }: PerformanceReportParams) {
     // copy history from the current gh-pages folder to new publish path
     console.log('Copying history');
     fs.ensureDirSync(publishPath);
-    fs.copySync(ghPagesPath, publishPath, { filter: (src, dest) => !src.includes('.git') });
+    fs.copySync(ghPagesPath, publishPath, { overwrite: false, filter: (src, dest) => !src.includes('.git') });
     // harmonize file names and copy latest performance metrics into performance publish path
     console.log('Copying performance metrics');
     harmonizeFileNames(performanceMetricsPath);
-    fs.ensureDirSync(`${publishPath}/${performancePublishPath}`);
-    fs.copySync(performanceMetricsPath, `${publishPath}/${performancePublishPath}`);
-    // generate performance report
+    const fullPerformancePath = `${publishPath}/${performancePublishPath}`;
+    fs.ensureDirSync(fullPerformancePath);
+    fs.copySync(performanceMetricsPath, fullPerformancePath);
+    // archive old metrics
+    if (maxAgeDays > 0) {
+        console.log(`Archiving metrics older than ${maxAgeDays} days`);
+        archiveOldMetrics(fullPerformancePath, maxAgeDays);
+    }
+    // generate performance report from remaining (non-archived) files
     console.log('Generating performance report');
-    generatePerformanceReport(`${publishPath}/${performancePublishPath}`);
+    generatePerformanceReport(fullPerformancePath);
 }
 
 /**
@@ -98,6 +112,27 @@ function harmonizeFileNames(path: string) {
         const runNumber = getRunNumber(fileNameWithoutExtension);
         if (runNumber >= 0) {
             fs.renameSync(`${path}/${file}`, `${path}/${referenceFileName[0]}_${runNumber}.txt`);
+        }
+    }
+}
+
+/**
+ * Moves metric files older than `maxAgeDays` into an `archive/YYYY/` subdirectory.
+ * Archived files are preserved but excluded from the active report.
+ */
+function archiveOldMetrics(path: string, maxAgeDays: number) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - maxAgeDays);
+
+    const files = fs.readdirSync(path).filter(hasTxtExtension);
+    for (const file of files) {
+        const fileDate = toDate(file);
+        if (fileDate < cutoff) {
+            const year = fileDate.getFullYear();
+            const archiveDir = `${path}/archive/${year}`;
+            fs.ensureDirSync(archiveDir);
+            fs.moveSync(`${path}/${file}`, `${archiveDir}/${file}`, { overwrite: true });
+            console.log(`  Archived: ${file} -> archive/${year}/`);
         }
     }
 }


### PR DESCRIPTION
#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-29

- Fix the browser performance report not being deployed: the `generate-report` job runs the browser report first, then the electron report. Both copy `gh-pages/` into `public/`, so the electron step was overwriting the freshly generated browser `index.html` with the stale version from `gh-pages`. Fixed by adding `overwrite: false` to the initial `copySync` call.
- Archive old performance reports to keep the report size manageable (Resolves #29). Keep only the last 90 reports by unique date and move older ones into `archive/YYYY/` subdirectories. Archived files are preserved on `gh-pages` but excluded from the active report chart.
- Use github-actions[bot] as committer for gh-pages deployments 

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The last recent performance workflow succeeded, however the browser report does not show anymore on the overview, see https://github.com/eclipse-theia/theia-e2e-test-suite/actions/runs/22721609806 and https://eclipse-theia.github.io/theia-e2e-test-suite/performance/.

This attempts to fix this and also archive reports when the number of reports is higher than 90.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
