### PR TITLE
ci: replace 3rd party action with native GH Pages deployment and stabilize CI against the extract-zip race 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,16 +87,28 @@ jobs:
           key: ${{ github.run_number }}
           fail-on-cache-miss: true
 
-      - name: Use Node.js 24.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 24.x
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # Playwright's default install path on Linux. Keyed on the lockfile so the cache
+          # is reused as long as the @playwright/test version (and therefore the required
+          # Chromium build) does not change. After the first successful extraction the
+          # `playwright install` step becomes a no-op.
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright Chromium
         shell: bash
@@ -132,16 +144,28 @@ jobs:
           key: ${{ github.run_number }}
           fail-on-cache-miss: true
 
-      - name: Use Node.js 24.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 24.x
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # Playwright's default install path on Linux. Keyed on the lockfile so the cache
+          # is reused as long as the @playwright/test version (and therefore the required
+          # Chromium build) does not change. After the first successful extraction the
+          # `playwright install` step becomes a no-op.
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright Chromium
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: "0 4 * * *" # Runs every day at 4am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: E2E Tests on ubuntu-22.04 with Node.js 22.x
@@ -187,10 +190,13 @@ jobs:
     name: Generate Report of E2E Electron Tests
     runs-on: ubuntu-22.04
     needs: [browser-tests, electron-tests]
+    permissions:
+      contents: write
 
     steps:
       - name: Get History
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        id: get_history
         if: always() && github.ref == 'refs/heads/main'
         continue-on-error: true
         with:
@@ -213,12 +219,46 @@ jobs:
           keep_reports: 100
           subfolder: allure
 
-      - name: Publish Report
+      - name: Push history to gh-pages branch
         if: always() && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HISTORY_FETCHED: ${{ steps.get_history.outcome == 'success' }}
+        run: |
+          REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Safety guard: we rebuild the full report from the previous gh-pages content and
+          # force-push the result. If the "Get History" checkout failed (it is best-effort so
+          # the very first run can succeed before gh-pages exists), the freshly built report is
+          # missing all prior history. Refuse to overwrite an existing branch in that case so a
+          # single transient checkout failure cannot wipe the accumulated report history.
+          if [ "$HISTORY_FETCHED" != "true" ] && git ls-remote --exit-code --heads "$REMOTE" gh-pages >/dev/null 2>&1; then
+            echo "::error::gh-pages exists but history was not fetched; refusing to force-push to avoid wiping report history."
+            exit 1
+          fi
+          cd allure-history
+          git init -q -b gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -q -m "Update report for run ${{ github.run_number }}"
+          git push -q --force "$REMOTE" gh-pages
+
+      - name: Upload Pages Artifact
+        if: always() && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          personal_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: allure-history
-          user_name: "github-actions[bot]"
-          user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          path: allure-history
+
+  deploy-report:
+    name: Deploy Report to GitHub Pages
+    runs-on: ubuntu-22.04
+    needs: [generate-report]
+    if: always() && github.ref == 'refs/heads/main'
+    environment: github-pages
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 5 * * *" # Runs every day at 5am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Performance benchmark on ubuntu-22.04 with Node.js 22.x
@@ -198,6 +201,8 @@ jobs:
     name: Create Performance Report
     runs-on: ubuntu-22.04
     needs: [run-browser-tests, run-electron-tests]
+    permissions:
+      contents: write
     steps:
       - name: Restore Build Result
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -208,6 +213,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Get History
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        id: get_history
         if: always() && github.ref == 'refs/heads/main'
         continue-on-error: true
         with:
@@ -227,12 +233,45 @@ jobs:
         if: always() && github.ref == 'refs/heads/main'
         shell: bash
         run: npm run performance-report-electron
-      - name: Publish Report
+      - name: Push history to gh-pages branch
         if: always() && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HISTORY_FETCHED: ${{ steps.get_history.outcome == 'success' }}
+        run: |
+          REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Safety guard: we rebuild the full report from the previous gh-pages content and
+          # force-push the result. If the "Get History" checkout failed (it is best-effort so
+          # the very first run can succeed before gh-pages exists), the freshly built report is
+          # missing all prior history. Refuse to overwrite an existing branch in that case so a
+          # single transient checkout failure cannot wipe the accumulated report history.
+          if [ "$HISTORY_FETCHED" != "true" ] && git ls-remote --exit-code --heads "$REMOTE" gh-pages >/dev/null 2>&1; then
+            echo "::error::gh-pages exists but history was not fetched; refusing to force-push to avoid wiping report history."
+            exit 1
+          fi
+          cd public
+          git init -q -b gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -q -m "Update performance report for run ${{ github.run_number }}"
+          git push -q --force "$REMOTE" gh-pages
+      - name: Upload Pages Artifact
+        if: always() && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          personal_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: public
-          user_name: "github-actions[bot]"
-          user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          path: public
+
+  deploy-report:
+    name: Deploy Report to GitHub Pages
+    runs-on: ubuntu-22.04
+    needs: [generate-report]
+    if: always() && github.ref == 'refs/heads/main'
+    environment: github-pages
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -95,15 +95,26 @@ jobs:
           path: ./*
           key: ${{ github.run_number }}
           fail-on-cache-miss: true
-      - name: Use Node.js 24.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 24.x
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
       - name: Use Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # Playwright's default install path on Linux. Keyed on the lockfile so the cache
+          # is reused as long as the @playwright/test version (and therefore the required
+          # Chromium build) does not change. After the first successful extraction the
+          # `playwright install` step becomes a no-op.
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright Chromium
         shell: bash
         run: npx playwright install chromium
@@ -143,15 +154,26 @@ jobs:
           path: ./*
           key: ${{ github.run_number }}
           fail-on-cache-miss: true
-      - name: Use Node.js 24.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 24.x
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
       - name: Use Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # Playwright's default install path on Linux. Keyed on the lockfile so the cache
+          # is reused as long as the @playwright/test version (and therefore the required
+          # Chromium build) does not change. After the first successful extraction the
+          # `playwright install` step becomes a no-op.
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright Chromium
         shell: bash
         run: npx playwright install chromium


### PR DESCRIPTION
#### chore: replace 3rd party action with native GH Pages deployment 
- Use actions/upload-pages-artifact + actions/deploy-pages instead of third-party action
- Split into separate build and deploy jobs
- Reduce permissions from contents:write to pages:write
- Repo setting gh_pages_build_type was changed from "legacy" to "workflow"

Contributed on behalf of STMicroelectronics

Depends on: https://github.com/eclipse-theia/.eclipsefdn/pull/17

#### ci: pin Playwright workflows to Node 22 and cache browsers 
- Pin both Playwright workflows to Node.js 22. The extract-zip race in playwright-core's bundled extractor is Node-24-specific and cannot be reached by npm overrides; Node 24 coverage already lives in the ci-cd.yml matrix, and UI tests do not need to gate on the Node version.
- Cache `~/.cache/ms-playwright` keyed on the lockfile so `playwright install chromium` is a no-op on warm runs. Independent CI speedup, follows Playwright's recommended CI pattern.

Contributed on behalf of STMicroelectronics