### PR TITLE
ci: fix gh-pages report publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,40 +215,56 @@ jobs:
         if: always() && github.ref == 'refs/heads/main'
         with:
           allure_results: allure-results
+          # Previous history/trend is read from the gh-pages checkout under ./gh-pages.
+          gh_pages: gh-pages
           allure_history: allure-history
           keep_reports: 100
           subfolder: allure
 
-      - name: Push history to gh-pages branch
+      - name: Update gh-pages branch
         if: always() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HISTORY_FETCHED: ${{ steps.get_history.outcome == 'success' }}
         run: |
-          REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          # Safety guard: we rebuild the full report from the previous gh-pages content and
-          # force-push the result. If the "Get History" checkout failed (it is best-effort so
-          # the very first run can succeed before gh-pages exists), the freshly built report is
-          # missing all prior history. Refuse to overwrite an existing branch in that case so a
-          # single transient checkout failure cannot wipe the accumulated report history.
-          if [ "$HISTORY_FETCHED" != "true" ] && git ls-remote --exit-code --heads "$REMOTE" gh-pages >/dev/null 2>&1; then
-            echo "::error::gh-pages exists but history was not fetched; refusing to force-push to avoid wiping report history."
-            exit 1
+          # The gh-pages branch hosts two independent reports, each owning a subfolder: this
+          # workflow owns "allure/", the performance workflow owns "performance/". To avoid one
+          # workflow wiping the other's report, we update ONLY our own subfolder inside a normal
+          # checkout of the branch and commit it - no fresh "git init" + force-push of the whole
+          # branch. This also sidesteps the permission problem of git-init'ing the allure action's
+          # root-owned output directory: we commit from the runner-owned ./gh-pages checkout.
+          if [ ! -d gh-pages/.git ]; then
+            # gh-pages did not exist yet (the best-effort checkout above found nothing to fetch):
+            # start the branch from scratch.
+            mkdir -p gh-pages
+            git -C gh-pages init -q -b gh-pages
+            git -C gh-pages remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           fi
-          cd allure-history
-          git init -q -b gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -q -m "Update report for run ${{ github.run_number }}"
-          git push -q --force "$REMOTE" gh-pages
+          # Replace our subfolder with the freshly generated report. The allure action already
+          # merged the previous trend (read from ./gh-pages) into allure-history/allure.
+          rm -rf gh-pages/allure
+          cp -r allure-history/allure gh-pages/allure
+          git -C gh-pages config user.name "github-actions[bot]"
+          git -C gh-pages config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C gh-pages add -A
+          git -C gh-pages commit -q -m "Update allure report for run ${{ github.run_number }}" || echo "No changes to commit"
+          # Retry with rebase so a concurrent performance run - which only ever touches
+          # performance/ - cannot cause a lost update. The two never edit the same paths, so any
+          # rebase here is conflict-free.
+          for attempt in 1 2 3; do
+            if git -C gh-pages push -q origin HEAD:gh-pages; then break; fi
+            echo "Push rejected, rebasing onto latest gh-pages (attempt ${attempt})"
+            git -C gh-pages fetch -q origin gh-pages && git -C gh-pages rebase -q origin/gh-pages || git -C gh-pages rebase --abort
+            if [ "${attempt}" = "3" ]; then echo "::error::Could not push to gh-pages after 3 attempts"; exit 1; fi
+          done
+          # Drop VCS metadata so it is not published as part of the site.
+          rm -rf gh-pages/.git
 
       - name: Upload Pages Artifact
         if: always() && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: allure-history
+          path: gh-pages
 
   deploy-report:
     name: Deploy Report to GitHub Pages
@@ -256,6 +272,12 @@ jobs:
     needs: [generate-report]
     if: always() && github.ref == 'refs/heads/main'
     environment: github-pages
+    # GitHub Pages allows only one active deployment per environment. Share this group with the
+    # performance workflow's deploy job so the two serialize instead of racing (which would make
+    # one deployment fail). cancel-in-progress: false queues them so both reports get published.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -233,35 +233,46 @@ jobs:
         if: always() && github.ref == 'refs/heads/main'
         shell: bash
         run: npm run performance-report-electron
-      - name: Push history to gh-pages branch
+      - name: Update gh-pages branch
         if: always() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HISTORY_FETCHED: ${{ steps.get_history.outcome == 'success' }}
         run: |
-          REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          # Safety guard: we rebuild the full report from the previous gh-pages content and
-          # force-push the result. If the "Get History" checkout failed (it is best-effort so
-          # the very first run can succeed before gh-pages exists), the freshly built report is
-          # missing all prior history. Refuse to overwrite an existing branch in that case so a
-          # single transient checkout failure cannot wipe the accumulated report history.
-          if [ "$HISTORY_FETCHED" != "true" ] && git ls-remote --exit-code --heads "$REMOTE" gh-pages >/dev/null 2>&1; then
-            echo "::error::gh-pages exists but history was not fetched; refusing to force-push to avoid wiping report history."
-            exit 1
+          # The gh-pages branch hosts two independent reports, each owning a subfolder: this
+          # workflow owns "performance/", the E2E workflow owns "allure/". To avoid one workflow
+          # wiping the other's report, we update ONLY our own subfolder inside a normal checkout
+          # of the branch and commit it - no fresh "git init" + force-push of the whole branch.
+          if [ ! -d gh-pages/.git ]; then
+            # gh-pages did not exist yet (the best-effort checkout above found nothing to fetch):
+            # start the branch from scratch.
+            mkdir -p gh-pages
+            git -C gh-pages init -q -b gh-pages
+            git -C gh-pages remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           fi
-          cd public
-          git init -q -b gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -q -m "Update performance report for run ${{ github.run_number }}"
-          git push -q --force "$REMOTE" gh-pages
+          # The report generator already merged the previous performance history (read from the
+          # ./gh-pages checkout) into public/performance. Copy just that subfolder over.
+          rm -rf gh-pages/performance
+          cp -r public/performance gh-pages/performance
+          git -C gh-pages config user.name "github-actions[bot]"
+          git -C gh-pages config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C gh-pages add -A
+          git -C gh-pages commit -q -m "Update performance report for run ${{ github.run_number }}" || echo "No changes to commit"
+          # Retry with rebase so a concurrent E2E run - which only ever touches allure/ - cannot
+          # cause a lost update. The two never edit the same paths, so any rebase is conflict-free.
+          for attempt in 1 2 3; do
+            if git -C gh-pages push -q origin HEAD:gh-pages; then break; fi
+            echo "Push rejected, rebasing onto latest gh-pages (attempt ${attempt})"
+            git -C gh-pages fetch -q origin gh-pages && git -C gh-pages rebase -q origin/gh-pages || git -C gh-pages rebase --abort
+            if [ "${attempt}" = "3" ]; then echo "::error::Could not push to gh-pages after 3 attempts"; exit 1; fi
+          done
+          # Drop VCS metadata so it is not published as part of the site.
+          rm -rf gh-pages/.git
       - name: Upload Pages Artifact
         if: always() && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: public
+          path: gh-pages
 
   deploy-report:
     name: Deploy Report to GitHub Pages
@@ -269,6 +280,12 @@ jobs:
     needs: [generate-report]
     if: always() && github.ref == 'refs/heads/main'
     environment: github-pages
+    # GitHub Pages allows only one active deployment per environment. Share this group with the
+    # CI workflow's deploy job so the two serialize instead of racing (which would make one
+    # deployment fail). cancel-in-progress: false queues them so both reports get published.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
#### Fix gh-pages report publishing

The CI (allure) and performance workflows both publish to the same gh-pages branch and the same GitHub Pages site, and they were overwriting each other.

Each workflow used to git init its own output folder and force-push it as the entire branch. The allure job only pushed its allure output, without the performance folder, so a successful allure run wiped the performance report and its history. The reason performance history survived so far is that the allure push had actually been failing with a permission error. The allure report action runs as root, so its output directory ended up root-owned and the runner user couldn't git init there. So on main the report history was broken while the performance runs looked fine.

#### What changed

Both workflows now share the branch nicely instead of fighting over it.

Each one updates only its own subfolder (allure or performance) inside a normal checkout of gh-pages, then commits and pushes. There is no more git init or force-push, so neither workflow can wipe the other, and the permission error goes away too.

The push uses a small rebase-and-retry so that a rare case of both workflows pushing at the same time can't drop an update. The two deploy jobs also share a concurrency group, because GitHub Pages only allows one active deployment at a time.

The result is that both the allure and performance reports keep their history, and every deploy publishes the full site. No repo settings need to change.

Contributed on behalf of STMicroelectronics