### PR TITLE
ci: bump allure-report-action to v1.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,7 +211,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate Report
-        uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c # v1.13
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 # v1.15
         if: always() && github.ref == 'refs/heads/main'
         with:
           allure_results: allure-results


### PR DESCRIPTION
Resolves the CI failure introduced when the amazoncorretto:8 base image dropped findutils, breaking allure report generation with "xargs is not available".

- bump simple-elf/allure-report-action from v1.13 to v1.15 (includes the upstream "add findutils to dockerfile" fix)

Contributed on behalf of STMicroelectronics


See failing CI jobs since Friday:
https://github.com/eclipse-theia/theia-e2e-test-suite/actions/workflows/main.yml